### PR TITLE
Update RLearner_classif_xgboost.R

### DIFF
--- a/R/RLearner_classif_xgboost.R
+++ b/R/RLearner_classif_xgboost.R
@@ -25,6 +25,7 @@ makeRLearner.classif.xgboost = function() {
       makeNumericLearnerParam(id = "max_delta_step", lower = 0, default = 0),
       makeNumericLearnerParam(id = "missing", default = NULL, tunable = FALSE, when = "both",
         special.vals = list(NA, NA_real_, NULL)),
+      makeNumericVectorLearnerParam(id = "monotone_constraints", default = 0),
       makeIntegerLearnerParam(id = "nthread", lower = 1L, tunable = FALSE),
       makeIntegerLearnerParam(id = "nrounds", default = 1L, lower = 1L),
       # FIXME nrounds seems to have no default in xgboost(), if it has 1, par.vals is redundant


### PR DESCRIPTION
Xgboost 0.6 version has monotone_constraints property added to the package. I added monotone_constraints as a parameter into the RLearner_classif_xgboost.R